### PR TITLE
Us8/pies index link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>RelationalRails</title>
-    <p><%= link_to "Pies Index", '/shops' %></p>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -12,6 +11,9 @@
   </head>
 
   <body>
+    <nav>
+      <%= link_to "Pies Index", '/shops' %>
+    </nav>  
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>RelationalRails</title>
+    <p><%= link_to "Pies Index", '/shops' %></p>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,1 +1,2 @@
 <h1>Welcome to Pie Shops!</h1>
+

--- a/spec/features/layouts/application_spec.rb
+++ b/spec/features/layouts/application_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "application layout file" do
+  before(:each) do
+    test_data
+  end
+
+  describe "Header Index Links" do
+    it "has a link to the pies index page on every page" do
+      visit '/shops'
+
+      within 'nav' do
+        expect(page).to have_link("Pies Index")
+      end
+
+      visit "/shops/#{@dub.id}"
+
+      within 'nav' do
+        expect(page).to have_link("Pies Index")
+      end
+
+      visit "/pies"
+
+      within 'nav' do
+        expect(page).to have_link("Pies Index")
+      end
+
+      visit "/shops/#{@dub.id}/pies"
+
+      within 'nav' do
+        expect(page).to have_link("Pies Index")
+      end
+    end
+  end
+end

--- a/spec/features/pies/index_spec.rb
+++ b/spec/features/pies/index_spec.rb
@@ -31,11 +31,4 @@ RSpec.describe "Pies Index Page", type: :feature do
       end
     end
   end
-  
-  describe "page links" do
-    it 'has a link to pies index at top of page' do
-      visit '/pies'
-      expect(page).to have_link("Pies Index")
-    end
-  end
 end

--- a/spec/features/pies/index_spec.rb
+++ b/spec/features/pies/index_spec.rb
@@ -8,27 +8,34 @@ RSpec.describe "Pies Index Page", type: :feature do
   describe "When I visit the Pie index page I see every pie and the following:" do
     it 'shows all pies and their attributes' do
       visit '/pies'
-
+      
       within "#pies_#{@mince.id}" do
         expect(page).to have_content("Name: #{@mince.name}")
         expect(page).to have_content("Category: #{@mince.category}")
         expect(page).to have_content("Wholesale?: #{@mince.wholesale}")
         expect(page).to have_content("Bake Time: #{@mince.bake_time}")
       end
-
+      
       within "#pies_#{@mush.id}" do
         expect(page).to have_content("Name: #{@mush.name}")
         expect(page).to have_content("Category: #{@mush.category}")
         expect(page).to have_content("Wholesale?: #{@mush.wholesale}")
         expect(page).to have_content("Bake Time: #{@mush.bake_time}")
       end
-
+      
       within "#pies_#{@spin.id}" do
         expect(page).to have_content("Name: #{@spin.name}")
         expect(page).to have_content("Category: #{@spin.category}")
         expect(page).to have_content("Wholesale?: #{@spin.wholesale}")
         expect(page).to have_content("Bake Time: #{@spin.bake_time}")
       end
+    end
+  end
+  
+  describe "page links" do
+    it 'has a link to pies index at top of page' do
+      visit '/pies'
+      expect(page).to have_link("Pies Index")
     end
   end
 end

--- a/spec/features/pies/show_spec.rb
+++ b/spec/features/pies/show_spec.rb
@@ -24,11 +24,4 @@ RSpec.describe "Pie's Show Page", type: :feature do
       expect(page).to have_content("Bake Time: #{@chick.bake_time}")
     end
   end
-  
-  describe "page links" do
-    it 'has a link to pies index at top of page' do
-      visit "/pies/#{@curry.id}"
-      expect(page).to have_link("Pies Index")
-    end
-  end
 end

--- a/spec/features/pies/show_spec.rb
+++ b/spec/features/pies/show_spec.rb
@@ -17,11 +17,18 @@ RSpec.describe "Pie's Show Page", type: :feature do
     
     it "shows all the attributes of a different pie" do
       visit "/pies/#{@chick.id}"
-
+      
       expect(page).to have_content("#{@chick.name}'s Show Page!")
       expect(page).to have_content("Category: #{@chick.category}")
       expect(page).to have_content("Wholesale?: #{@chick.wholesale}")
       expect(page).to have_content("Bake Time: #{@chick.bake_time}")
+    end
+  end
+  
+  describe "page links" do
+    it 'has a link to pies index at top of page' do
+      visit "/pies/#{@curry.id}"
+      expect(page).to have_link("Pies Index")
     end
   end
 end

--- a/spec/features/shops/index_spec.rb
+++ b/spec/features/shops/index_spec.rb
@@ -21,12 +21,5 @@ RSpec.describe "Shops index page", type: :feature do
       expect(@truck.name).to appear_before(@dub.name)
       expect(@dub.name).to_not appear_before(@flushing.name)
     end
-  
-    describe "page links" do
-      it 'has a link to pies index at top of page' do
-        visit '/shops'
-        expect(page).to have_link("Pies Index")
-      end
-    end
   end
 end

--- a/spec/features/shops/index_spec.rb
+++ b/spec/features/shops/index_spec.rb
@@ -16,10 +16,17 @@ RSpec.describe "Shops index page", type: :feature do
     
     it 'lists shops in order from most recently created' do
       visit '/shops'
-
+      
       expect(@flushing.name).to appear_before(@truck.name)
       expect(@truck.name).to appear_before(@dub.name)
       expect(@dub.name).to_not appear_before(@flushing.name)
+    end
+  
+    describe "page links" do
+      it 'has a link to pies index at top of page' do
+        visit '/shops'
+        expect(page).to have_link("Pies Index")
+      end
     end
   end
 end

--- a/spec/features/shops/pies/index_spec.rb
+++ b/spec/features/shops/pies/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Shop Pie's index Page", type: :feature do
     
     it "shows each pies attributes" do
       visit "/shops/#{@dub.id}/pies"
-
+      
       within "#pies_#{@mince.id}" do
         expect(page).to have_content(@mince.name)
         expect(page).to have_content(@mince.category)
@@ -34,7 +34,7 @@ RSpec.describe "Shop Pie's index Page", type: :feature do
         expect(page).to have_content(@mush.bake_time)
         expect(page).to_not have_content(@spin.name)
       end
-
+      
       within "#pies_#{@curry.id}" do
         expect(page).to have_content(@curry.name)
         expect(page).to have_content(@curry.category)
@@ -42,6 +42,13 @@ RSpec.describe "Shop Pie's index Page", type: :feature do
         expect(page).to have_content(@curry.bake_time)
         expect(page).to_not have_content(@spin.name)
       end
+    end
+  end
+  
+  describe "page links" do
+    it 'has a link to pies index at top of page' do
+      visit "/shops/#{@dub.id}/pies"
+      expect(page).to have_link("Pies Index")
     end
   end
 end

--- a/spec/features/shops/pies/index_spec.rb
+++ b/spec/features/shops/pies/index_spec.rb
@@ -44,11 +44,4 @@ RSpec.describe "Shop Pie's index Page", type: :feature do
       end
     end
   end
-  
-  describe "page links" do
-    it 'has a link to pies index at top of page' do
-      visit "/shops/#{@dub.id}/pies"
-      expect(page).to have_link("Pies Index")
-    end
-  end
 end

--- a/spec/features/shops/show_spec.rb
+++ b/spec/features/shops/show_spec.rb
@@ -25,13 +25,20 @@ RSpec.describe "Shop's show page", type: :feature do
       
       it 'can show the number of pie varieties at this shop' do
         visit "/shops/#{@dub.id}"
-
+        
         expect(page).to have_content("Pie Varieties Available: 3")
-
+        
         visit "/shops/#{@truck.id}"
-
+        
         expect(page).to have_content("Pie Varieties Available: 4")
       end
+    end
+  end
+  
+  describe "page links" do
+    it 'has a link to pies index at top of page' do
+      visit "/shops/#{@dub.id}"
+      expect(page).to have_link("Pies Index")
     end
   end
 end

--- a/spec/features/shops/show_spec.rb
+++ b/spec/features/shops/show_spec.rb
@@ -34,11 +34,4 @@ RSpec.describe "Shop's show page", type: :feature do
       end
     end
   end
-  
-  describe "page links" do
-    it 'has a link to pies index at top of page' do
-      visit "/shops/#{@dub.id}"
-      expect(page).to have_link("Pies Index")
-    end
-  end
 end


### PR DESCRIPTION
This PR contains the work for us 8. A link to the pies index page is at the top of every page.
The link was added to the application.html file within the layouts folder in the views. Will be adding more links to this in the future.
Created a layouts spec file with tests to go to different pages and confirm the link is there.